### PR TITLE
Feature/#34 player class

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,7 @@
         "ts": "never",
         "tsx": "never"
       }
-   ],
+    ],
     "import/order": [
       "error",
       {

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ WarPlayer ..> GameDecision
         +isThreeOfAKind() bool
         +isTwoPair() bool
         +isOnePair() bool
-        +countRanks() number[] 
+        +countRanks() number[]
     }
 
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,18 @@ WarPlayer ..> GameDecision
     }
 
     class PorkerPlayer{
-        + getHandRank() number
+        -List~string~ suits
+        -List~int~ ranks
+        +getHandRank() number
+        +isStraightFlush() bool
+        +isFourOfAKind() bool
+        +isFullHouse() bool
+        +isFlush() bool
+        +isStraight() bool
+        +isThreeOfAKind() bool
+        +isTwoPair() bool
+        +isOnePair() bool
+        +countRanks() number[] 
     }
 
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ WarPlayer ..> GameDecision
         -string gamePhase
         -List~string~ resultsLog
         #Deck deck
-        -Abstract List~Player~ players
+        +Abstract List~Player~ players
 
         +Abstract assignPlayerHands() void
         +Abstract clearPlayerHandsAndBets() void
@@ -374,7 +374,7 @@ WarPlayer ..> GameDecision
 
     class Deck {
         -string gameType
-        -List~Card~ Cards
+        #List~Card~ Cards
 
         +generateDeck() void
         +shuffle() void

--- a/src/model/blackJack/BlackjackPlayer.ts
+++ b/src/model/blackJack/BlackjackPlayer.ts
@@ -2,13 +2,6 @@ import GameDecision from '../common/GameDesicion'
 import Player from '../common/Player'
 
 export default class BlackjackPlayer extends Player {
-  /*
-      ?Number userData : モデル外から渡されるパラメータ. nullになることもある.
-      検討：Number houseCard : ハウスの表向きのカードのランク。
-      return GameDecision : 状態を考慮した上で、プレイヤーが行った決定。
-
-        このメソッドは、どのようなベットやアクションを取るべきかというプレイヤーの決定を取得する. プレイヤーのタイプ、ハンド、チップの状態を読み取り、GameDecisionを返す.
- */
   promptPlayer(): GameDecision {
     let action = ''
     const hand = this.getHandScore()

--- a/src/model/common/Card.ts
+++ b/src/model/common/Card.ts
@@ -46,6 +46,23 @@ export default class Card {
           K: 13,
         }
         break
+      case 'poker':
+        rankToNumber = {
+          A: 0,
+          '2': 1,
+          '3': 2,
+          '4': 3,
+          '5': 4,
+          '6': 5,
+          '7': 6,
+          '8': 7,
+          '9': 8,
+          '10': 9,
+          J: 10,
+          Q: 11,
+          K: 12,
+        }
+        break
       default:
         rankToNumber = {
           A: 1,

--- a/src/model/common/Card.ts
+++ b/src/model/common/Card.ts
@@ -1,7 +1,7 @@
 export default class Card {
-  suit: string
+  readonly suit: string
 
-  rank: string
+  readonly rank: string
 
   constructor(suit: string, rank: string) {
     this.suit = suit

--- a/src/model/common/Card.ts
+++ b/src/model/common/Card.ts
@@ -1,11 +1,19 @@
 export default class Card {
-  readonly suit: string
+  readonly _suit: string
 
-  readonly rank: string
+  readonly _rank: string
 
   constructor(suit: string, rank: string) {
-    this.suit = suit
-    this.rank = rank
+    this._suit = suit
+    this._rank = rank
+  }
+
+  get suit(): string {
+    return this._suit
+  }
+
+  get rank(): string {
+    return this._rank
   }
 
   // カードのゲームごとの強さを整数で返す
@@ -81,6 +89,6 @@ export default class Card {
         }
         break
     }
-    return rankToNumber[this.rank] ?? 0 // if runktoNumber[this.rank] is undefined, the function returns 0
+    return rankToNumber[this._rank] ?? 0 // if runktoNumber[this.rank] is undefined, the function returns 0
   }
 }

--- a/src/model/common/Card.ts
+++ b/src/model/common/Card.ts
@@ -1,19 +1,21 @@
-export default class Card {
-  readonly _suit: string
+/* eslint no-underscore-dangle:0 */
 
-  readonly _rank: string
+export default class Card {
+  readonly p_suit: string
+
+  readonly p_rank: string
 
   constructor(suit: string, rank: string) {
-    this._suit = suit
-    this._rank = rank
+    this.p_suit = suit
+    this.p_rank = rank
   }
 
   get suit(): string {
-    return this._suit
+    return this.p_suit
   }
 
   get rank(): string {
-    return this._rank
+    return this.p_rank
   }
 
   // カードのゲームごとの強さを整数で返す
@@ -89,6 +91,6 @@ export default class Card {
         }
         break
     }
-    return rankToNumber[this._rank] ?? 0 // if runktoNumber[this.rank] is undefined, the function returns 0
+    return rankToNumber[this.p_rank] ?? 0 // if runktoNumber[this.rank] is undefined, the function returns 0
   }
 }

--- a/src/model/common/Deck.ts
+++ b/src/model/common/Deck.ts
@@ -1,7 +1,7 @@
 import Card from './Card'
 
 export default class Deck {
-  gameType: string
+  private gameType: string
 
   protected cards: Card[]
 

--- a/src/model/common/Deck.ts
+++ b/src/model/common/Deck.ts
@@ -3,7 +3,7 @@ import Card from './Card'
 export default class Deck {
   gameType: string
 
-  cards: Card[]
+  protected cards: Card[]
 
   constructor(gameType: string) {
     // ゲームの種類

--- a/src/model/common/GameDesicion.ts
+++ b/src/model/common/GameDesicion.ts
@@ -1,7 +1,7 @@
 export default class GameDecision {
-  private _action: string
+  private p_action: string
 
-  private _amount: number
+  private p_amount: number
 
   /*
       String action : プレイヤーのアクションの選択（ブラックジャックでは、hit、standなど）
@@ -9,23 +9,23 @@ export default class GameDecision {
       これはPlayer.promptPlayer()が常にreturnする、標準化されたフォーマットです。
   */
   constructor(action: string, amount: number) {
-    this._action = action
-    this._amount = amount
+    this.p_action = action
+    this.p_amount = amount
   }
 
   get action(): string {
-    return this._action
+    return this.p_action
   }
 
   set action(action: string) {
-    this._action = action
+    this.p_action = action
   }
 
   get amount(): number {
-    return this._amount
+    return this.p_amount
   }
 
   set amount(amount: number) {
-    this._amount = amount
+    this.p_amount = amount
   }
 }

--- a/src/model/common/GameDesicion.ts
+++ b/src/model/common/GameDesicion.ts
@@ -1,7 +1,7 @@
 export default class GameDecision {
-  action: string
+  private _action: string
 
-  amount: number
+  private _amount: number
 
   /*
       String action : プレイヤーのアクションの選択（ブラックジャックでは、hit、standなど）
@@ -9,7 +9,23 @@ export default class GameDecision {
       これはPlayer.promptPlayer()が常にreturnする、標準化されたフォーマットです。
   */
   constructor(action: string, amount: number) {
-    this.action = action
-    this.amount = amount
+    this._action = action
+    this._amount = amount
+  }
+
+  get action(): string {
+    return this._action
+  }
+
+  set action(action: string) {
+    this._action = action
+  }
+
+  get amount(): number {
+    return this._amount
+  }
+
+  set amount(amount: number) {
+    this._amount = amount
   }
 }

--- a/src/model/common/Player.ts
+++ b/src/model/common/Player.ts
@@ -2,19 +2,19 @@ import Card from './Card'
 import GameDecision from './GameDesicion'
 
 export default abstract class Player {
-  readonly name: string
+  readonly _name: string
 
-  playerType: string
+  readonly _playerType: string
 
-  chips: number
+  private _chips: number
 
-  bet: number
+  private _bet: number
 
-  winAmount: number
+  private _winAmount: number
 
-  gameStatus: string
+  private _gameStatus: string
 
-  hand: Array<Card> = []
+  private _hand: Array<Card> = []
 
   /*
         String name : プレイヤーの名前
@@ -25,12 +25,56 @@ export default abstract class Player {
         gameStatus : ゲームの状態 {'betting', 'acting'}
     */
   constructor(name: string, playerType: string, chips = 400) {
-    this.name = name
-    this.playerType = playerType
-    this.chips = chips
-    this.bet = 0
-    this.winAmount = 0
-    this.gameStatus = 'bet'
+    this._name = name
+    this._playerType = playerType
+    this._chips = chips
+    this._bet = 0
+    this._winAmount = 0
+    this._gameStatus = 'bet'
+  }
+
+  get name(): string {
+    return this._name
+  }
+
+  get playerType(): string {
+    return this._playerType
+  }
+
+  get chips(): number {
+    return this._chips
+  }
+
+  set chips(chips: number) {
+    this._chips = chips
+  }
+
+  get bet(): number {
+    return this._bet
+  }
+
+  set bet(bet: number) {
+    this._bet = bet
+  }
+
+  get winAmount(): number {
+    return this._winAmount
+  }
+
+  set winAmount(winAmount: number) {
+    this._winAmount = winAmount
+  }
+
+  get gameStatus(): string {
+    return this._gameStatus
+  }
+
+  set gameStatus(gameStatus: string) {
+    this._gameStatus = gameStatus
+  }
+
+  get hand(): Array<Card> {
+    return this._hand
   }
 
   abstract promptPlayer(): GameDecision

--- a/src/model/common/Player.ts
+++ b/src/model/common/Player.ts
@@ -2,19 +2,19 @@ import Card from './Card'
 import GameDecision from './GameDesicion'
 
 export default abstract class Player {
-  readonly _name: string
+  readonly p_name: string
 
-  readonly _playerType: string
+  readonly p_playerType: string
 
-  private _chips: number
+  private p_chips: number
 
-  private _bet: number
+  private p_bet: number
 
-  private _winAmount: number
+  private p_winAmount: number
 
-  private _gameStatus: string
+  private p_gameStatus: string
 
-  private _hand: Array<Card> = []
+  private p_hand: Array<Card> = []
 
   /*
         String name : プレイヤーの名前
@@ -25,56 +25,56 @@ export default abstract class Player {
         gameStatus : ゲームの状態 {'betting', 'acting'}
     */
   constructor(name: string, playerType: string, chips = 400) {
-    this._name = name
-    this._playerType = playerType
-    this._chips = chips
-    this._bet = 0
-    this._winAmount = 0
-    this._gameStatus = 'bet'
+    this.p_name = name
+    this.p_playerType = playerType
+    this.p_chips = chips
+    this.p_bet = 0
+    this.p_winAmount = 0
+    this.p_gameStatus = 'bet'
   }
 
   get name(): string {
-    return this._name
+    return this.p_name
   }
 
   get playerType(): string {
-    return this._playerType
+    return this.p_playerType
   }
 
   get chips(): number {
-    return this._chips
+    return this.p_chips
   }
 
   set chips(chips: number) {
-    this._chips = chips
+    this.p_chips = chips
   }
 
   get bet(): number {
-    return this._bet
+    return this.p_bet
   }
 
   set bet(bet: number) {
-    this._bet = bet
+    this.p_bet = bet
   }
 
   get winAmount(): number {
-    return this._winAmount
+    return this.p_winAmount
   }
 
   set winAmount(winAmount: number) {
-    this._winAmount = winAmount
+    this.p_winAmount = winAmount
   }
 
   get gameStatus(): string {
-    return this._gameStatus
+    return this.p_gameStatus
   }
 
   set gameStatus(gameStatus: string) {
-    this._gameStatus = gameStatus
+    this.p_gameStatus = gameStatus
   }
 
   get hand(): Array<Card> {
-    return this._hand
+    return this.p_hand
   }
 
   abstract promptPlayer(): GameDecision

--- a/src/model/common/Player.ts
+++ b/src/model/common/Player.ts
@@ -2,7 +2,7 @@ import Card from './Card'
 import GameDecision from './GameDesicion'
 
 export default abstract class Player {
-  name: string
+  readonly name: string
 
   playerType: string
 

--- a/src/model/poker/PokerPlayer.ts
+++ b/src/model/poker/PokerPlayer.ts
@@ -2,6 +2,20 @@ import GameDecision from '../common/GameDesicion'
 import Player from '../common/Player'
 
 export default class PokerPlayer extends Player {
+  private suits: string[]
+
+  private ranks: number[]
+
+  /* 
+    _suits: string[] 手札のスートを格納する配列
+    _ranks: string[] 手札を番号に変換し,ソートして格納する配列
+  */
+  constructor(name: string, playerType: string, chips = 400) {
+    super(name, playerType, chips)
+    this.suits = this.hand.map((card) => card.suit)
+    this.ranks = this.hand.map((card) => card.getRankNumber('poker')).sort((a, b) => a - b)
+  }
+
   promptPlayer(): GameDecision {
     return new GameDecision('Under development', this.bet)
   }
@@ -11,6 +25,102 @@ export default class PokerPlayer extends Player {
   }
 
   getHandRank(): number {
-    return this.hand.length
+    let num: number = 0
+    if (this.isRoyalFlush()) {
+      num = 10
+    } else if (this.isStraightFlush()) {
+      num = 9
+    } else if (this.isFourOfAKind()) {
+      num = 8
+    } else if (this.isFullHouse()) {
+      num = 7
+    } else if (this.isFlush()) {
+      num = 6
+    } else if (this.isStraight()) {
+      num = 5
+    } else if (this.isThreeOfAKind()) {
+      num = 4
+    } else if (this.isTwoPair()) {
+      num = 3
+    } else if (this.isOnePair()) {
+      num = 2
+    } else {
+      num = 1
+    }
+    return num
+  }
+
+  // 各役の判定メソッド
+  // ロイヤルストレートフラッシュ(10, 11, 12, 13, 1の5枚でsuitが同じ)
+  isRoyalFlush(): boolean {
+    return this.isFlush() && this.isStraight() && this.ranks[0] === 10
+  }
+
+  // ストレートフラッシュ
+  isStraightFlush(): boolean {
+    return this.isFlush() && this.isStraight()
+  }
+
+  // フォーカード
+  isFourOfAKind(): boolean {
+    const rankCounts = this.countRanks()
+    return rankCounts.includes(4)
+  }
+
+  // フルハウス（同数位のカード3枚とペア）
+  isFullHouse(): boolean {
+    const rankCounts = this.countRanks()
+    return rankCounts.includes(3) && rankCounts.includes(2)
+  }
+
+  // フラッシュ(一種類のsuit)
+  isFlush(): boolean {
+    return new Set(this.suits).size === 1
+  }
+
+  // ストレート（5枚のカードの数位が連続・10JQKAはストレート・KA2などは×）
+  isStraight(): boolean {
+    if (
+      this.ranks[0] === 0 &&
+      this.ranks[1] === 9 &&
+      this.ranks[2] === 10 &&
+      this.ranks[3] === 11 &&
+      this.ranks[4] === 12
+    ) {
+      return true
+    }
+    for (let i = 0; i < 4; i += 1) {
+      if (this.ranks[i + 1] - this.ranks[i] !== 1) {
+        return false
+      }
+    }
+    return true
+  }
+
+  // スリーカード
+  isThreeOfAKind(): boolean {
+    const rankCounts = this.countRanks()
+    return rankCounts.includes(3)
+  }
+
+  // ツーペア
+  isTwoPair(): boolean {
+    const rankCounts = this.countRanks()
+    return rankCounts.filter((count) => count === 2).length === 2
+  }
+
+  // ワンペア
+  isOnePair(): boolean {
+    const rankCounts = this.countRanks()
+    return rankCounts.includes(2)
+  }
+
+  // 各ランクの数を数えます
+  countRanks(): number[] {
+    const counts: number[] = Array(13).fill(0)
+    for (let i = 0; i < this.ranks.length; i += 1) {
+      counts[this.ranks[i]] += 1
+    }
+    return counts
   }
 }


### PR DESCRIPTION
## チケットへのリンク

- #34

## やったこと

- 各種クラスのアクセス修飾子の修正
- PokerPlayerクラスの役判定を追加
- `npm run lint`でのコード修正

## やらないこと

- SpeedPlayer, PokerPlayerの`promptPlayer()`によるCPU, houseの行動実装

## できるようになること（ユーザ目線）
- なし

## できなくなること（ユーザ目線）

-なし

## 動作確認

- なし

## その他

- ブラックジャックの基本的な実装・Warの実装・Pokerの役判定に関してはPlayerは完了
- ブラックジャックの親の行動は完了・CPUごとに強さをいれるなら,　複雑な処理を追加する必要あり.
- SpeedとPokerのCPUとhouseの行動を実装する必要がある.
