### PR TITLE
#70 modified preloadScene

### DIFF
--- a/src/Phaser/PreloadScene.ts
+++ b/src/Phaser/PreloadScene.ts
@@ -1,8 +1,51 @@
 import * as path from 'path'
 import { CARD_ATLAS_KEY } from '@/Factories/cardFactory'
+import { loadText } from '@/utility/constants'
 
 export default class PreloadScene extends Phaser.Scene {
   preload() {
+    const { width, height } = this.cameras.main
+    // ロードバーの背景
+    const progressBox = this.add.graphics()
+    progressBox.fillStyle(0x222222, 0.8)
+    progressBox.fillRect(width / 2 - 300, height / 2 - 120, 600, 240)
+
+    // ロードバーを作成
+    const progressBar = this.add.graphics()
+
+    // テキスト
+    const loadingText = this.make.text({
+      x: width / 2,
+      y: height / 2 - 50,
+      text: 'Loading...',
+      style: loadText,
+    })
+    loadingText.setOrigin(0.5, 0.5)
+
+    const percentText = this.make.text({
+      x: width / 2,
+      y: height / 2 + 30,
+      text: '0%',
+      style: loadText,
+    })
+    percentText.setOrigin(0.5, 0.5)
+
+    // ロードイベント
+    this.load.on('progress', (value: number) => {
+      percentText.setText(`${Math.floor(value * 100)}%`)
+      progressBar.clear()
+      progressBar.fillStyle(0xffffff, 1)
+      progressBar.fillRect(width / 2 - 150, height / 2 - 30, 300 * value, 30)
+    })
+
+    this.load.on('complete', () => {
+      progressBar.destroy()
+      progressBox.destroy()
+      loadingText.destroy()
+      percentText.destroy()
+    })
+
+    // アセットの読み込み
     this.load.atlasXML(
       CARD_ATLAS_KEY,
       path.join('/assets/Cards', 'playingCards.png'),

--- a/src/utility/constants.ts
+++ b/src/utility/constants.ts
@@ -6,6 +6,11 @@ export const textStyle = {
   strokeThickness: 5,
 }
 
+export const loadText = {
+  font: '20px monospace',
+  fill: '#FFFFFF',
+}
+
 export const CARD_WIDTH = 140
 export const CARD_HEIGHT = 190
 


### PR DESCRIPTION
## チケットへのリンク

- #70

## やったこと

- 読み込み時の画面をpreloadScene.tsに処理を追加して実現

## やらないこと

- なし

## できるようになること（ユーザ目線）

- 読み込み画面表示

## できなくなること（ユーザ目線）

- なし

## 動作確認

- BlackjackとSpeedで確認
https://github.com/recursion-team-a/card-games/assets/127278864/3aa680e9-6edf-476a-993e-1a792c39fad9

## その他

- BaseScene.tsでpreloadScene.tsは継承されているので, BaseSceneを継承しているゲームであれば表示される.
- 参考URL：https://gamedevacademy.org/creating-a-preloading-screen-in-phaser-3/?a=13
