### PR TITLE
Feature/#58 poker cpu

### DIFF
--- a/src/Phaser/blackjack/BlackjackScene.ts
+++ b/src/Phaser/blackjack/BlackjackScene.ts
@@ -198,7 +198,7 @@ export default class Blackjack extends BaseScene {
         this.input.once(
           'pointerdown',
           () => {
-            this.scene.start('BetScene')
+            window.location.href = '/studio'
           },
           this,
         )

--- a/src/Phaser/common/BaseScene.ts
+++ b/src/Phaser/common/BaseScene.ts
@@ -43,7 +43,7 @@ export default class BaseScene extends PreloadScene {
     this.INITIAL_TIME = 2
 
     button.on('pointerdown', () => {
-      this.scene.start('BetScene')
+      window.location.href = '/studio'
     })
     this.gameZone = this.add.zone(width * 0.5, height * 0.5, width, height)
   }

--- a/src/Phaser/config.ts
+++ b/src/Phaser/config.ts
@@ -1,6 +1,5 @@
 import Phaser from 'phaser'
 import BetScene from './BetScene'
-import PreloadScene from './PreloadScene'
 import Blackjack from './blackjack/BlackjackScene'
 
 const gameConfig: Phaser.Types.Core.GameConfig = {
@@ -25,7 +24,7 @@ const gameConfig: Phaser.Types.Core.GameConfig = {
       gravity: { y: 200 },
     },
   },
-  scene: [PreloadScene, BetScene, Blackjack],
+  scene: [BetScene, Blackjack],
 }
 
 export default gameConfig

--- a/src/Phaser/poker/PokerScene.ts
+++ b/src/Phaser/poker/PokerScene.ts
@@ -681,7 +681,6 @@ export default class Poker extends BaseScene {
     })
 
     return Object.keys(suitCountMap).some((suit) => suitCountMap[suit] >= 4 && suit === cardSuit)
-    return false
   }
 
   private static isCardPartOfStraight(cardRank: number, ranks: number[]): boolean {

--- a/src/Phaser/poker/constants/handRank.ts
+++ b/src/Phaser/poker/constants/handRank.ts
@@ -24,4 +24,6 @@ const HAND_RANK_MAP = new Map([
   ['ROYAL_STRAIGHT_FLUSH', 10],
 ])
 
-export { HAND_RANK, HAND_RANK_MAP }
+const RANK_CHOICES = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K']
+
+export { HAND_RANK, HAND_RANK_MAP, RANK_CHOICES }

--- a/src/model/poker/PokerPlayer.ts
+++ b/src/model/poker/PokerPlayer.ts
@@ -1,7 +1,5 @@
 import Card from '../common/CardImage'
-import { HAND_RANK, HAND_RANK_MAP } from '@/Phaser/poker/constants/handRank'
-
-const RANK_CHOICES = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K']
+import { HAND_RANK, HAND_RANK_MAP, RANK_CHOICES } from '@/Phaser/poker/constants/handRank'
 
 export default class PokerPlayer {
   private suits: string[]
@@ -50,7 +48,7 @@ export default class PokerPlayer {
     return this.hand.length
   }
 
-  getHandRank(): number {
+  getRanks(): number[] {
     const ranks: number[] = this.hand
       .map((card) =>
         RANK_CHOICES.indexOf(
@@ -58,6 +56,12 @@ export default class PokerPlayer {
         ),
       )
       .sort((a, b) => a - b)
+
+    return ranks
+  }
+
+  getHandRank(): number {
+    const ranks = this.getRanks()
 
     // フラッシュ
     const isFlush = this.hand.every((card) => card.suit === this.hand[0].suit)

--- a/yarn.lock
+++ b/yarn.lock
@@ -624,10 +624,15 @@
   dependencies:
     glob "7.1.7"
 
-"@next/swc-darwin-arm64@13.4.4":
+"@next/swc-linux-x64-gnu@13.4.4":
   version "13.4.4"
-  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.4.tgz"
-  integrity sha512-xfjgXvp4KalNUKZMHmsFxr1Ug+aGmmO6NWP0uoh4G3WFqP/mJ1xxfww0gMOeMeSq/Jyr5k7DvoZ2Pv+XOITTtw==
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.4.tgz"
+  integrity sha512-PX706XcCHr2FfkyhP2lpf+pX/tUvq6/ke7JYnnr0ykNdEMo+sb7cC/o91gnURh4sPYSiZJhsF2gbIqg9rciOHQ==
+
+"@next/swc-linux-x64-musl@13.4.4":
+  version "13.4.4"
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.4.tgz"
+  integrity sha512-TKUUx3Ftd95JlHV6XagEnqpT204Y+IsEa3awaYIjayn0MOGjgKZMZibqarK3B1FsMSPaieJf2FEAcu9z0yT5aA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2340,11 +2345,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@^2.3.2, fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
## チケットへのリンク

- #58

## やったこと

- PokerのCPUアルゴリズム（手札交換）の修正

## やらないこと

- CPUの強さ選択
- ベッティングのアルゴリズム（raiseやcheckなど）

## できるようになること（ユーザ目線）

- CPUと対戦

## できなくなること（ユーザ目線）

- なし

## 動作確認

- 実際にプレーして, houseの手札をコンソールに表示し, カード交換が適切に行われているか確認

## その他

- 手札交換アルゴリズムを実装しました.主な内容は, 5枚で点数高い役がすでにできている場合は交換なし. ペアやスリーカードなどを構成しているカードは保持. あと1枚でフラッシュやストレートになる場合は, その1枚のみ交換するようにした. 