### PR TITLE
Feature/#78 continue

### DIFF
--- a/src/Phaser/blackjack/BlackjackScene.ts
+++ b/src/Phaser/blackjack/BlackjackScene.ts
@@ -93,6 +93,7 @@ export default class Blackjack extends BaseScene {
     toX: number,
     toY: number,
     isFaceDown: boolean,
+    isEnd?: boolean | undefined,
   ): void {
     const card: Card | undefined = deck.drawOne()
 
@@ -103,10 +104,12 @@ export default class Blackjack extends BaseScene {
     }
 
     player.addHand(card)
-    if (player === this.dealerHand) {
+    if (player === this.dealerHand && isEnd) {
+      this.setDealerScoreText()
+    }
+    if (player === this.playerHand) {
       this.setPlayerScoreText()
     }
-    this.setDealerScoreText()
     this.children.bringToTop(card)
     card.playMoveTween(toX, toY)
   }
@@ -330,6 +333,7 @@ export default class Blackjack extends BaseScene {
         (this.dealerHandZone as Zone).x + CARD_WIDTH * (handleLen * 0.3 - 0.15),
         (this.dealerHandZone as Zone).y,
         false,
+        true,
       )
       setTimeout(() => this.drawCardsUntil17(), 500)
       return
@@ -358,7 +362,7 @@ export default class Blackjack extends BaseScene {
 
   private setUpDealerScoreText(): void {
     this.dealerScoreText = this.add.text(0, 200, '', textStyle)
-    this.setDealerScoreText()
+    this.setDealerScoreText(true)
     Phaser.Display.Align.In.TopCenter(this.dealerScoreText, this.gameZone as Zone, 0, -20)
   }
 
@@ -368,8 +372,12 @@ export default class Blackjack extends BaseScene {
     Phaser.Display.Align.In.BottomCenter(this.playerScoreText, this.gameZone as Zone, 0, -20)
   }
 
-  private setDealerScoreText() {
-    ;(this.dealerScoreText as Text).setText(`Dealer Score: ${this.dealerHand?.getHandScore()}`)
+  private setDealerScoreText(isStart?: boolean | undefined) {
+    if (isStart) {
+      ;(this.dealerScoreText as Text).setText('Dealer Score: ??')
+    } else {
+      ;(this.dealerScoreText as Text).setText(`Dealer Score: ${this.dealerHand?.getHandScore()}`)
+    }
   }
 
   private setPlayerScoreText() {

--- a/src/Phaser/blackjack/BlackjackScene.ts
+++ b/src/Phaser/blackjack/BlackjackScene.ts
@@ -180,34 +180,41 @@ export default class Blackjack extends BaseScene {
   private endHand(result: GameResult) {
     this.players = []
     const resultObj = this.payout(result)
-    const graphics = this.add.graphics({
-      fillStyle: { color: 0x000000, alpha: 0.75 },
-    })
-    const { width, height } = this.sys.game.canvas
-    const square = Phaser.Geom.Rectangle.FromXY(0, 0, width, height)
-    graphics.fillRectShape(square)
-    const resultText: Text = this.add.text(
-      0,
-      0,
-      `${result} ${makeMoneyString(resultObj.winAmount)}`,
-      textStyle,
-    )
-    resultText.setColor('#ffde3d')
-    Phaser.Display.Align.In.Center(resultText, this.gameZone as Zone)
-    this.fadeOutButton()
-    this.input.once(
-      'pointerdown',
-      () => {
-        this.input.once(
-          'pointerdown',
-          () => {
-            window.location.href = '/studio'
-          },
-          this,
-        )
-      },
-      this,
-    )
+    if (!this.betScene?.money || this.betScene.money <= 0) {
+      this.gameOver()
+    } else {
+      const graphics = this.add.graphics({
+        fillStyle: { color: 0x000000, alpha: 0.75 },
+      })
+      const { width, height } = this.sys.game.canvas
+      const square = Phaser.Geom.Rectangle.FromXY(0, 0, width, height)
+      graphics.fillRectShape(square)
+      const resultText: Text = this.add.text(
+        0,
+        0,
+        `${result} ${makeMoneyString(resultObj.winAmount)}`,
+        textStyle,
+      )
+      resultText.setColor('#ffde3d')
+      Phaser.Display.Align.In.Center(resultText, this.gameZone as Zone)
+      this.fadeOutButton()
+      if (this.betScene) {
+        this.betScene.bet = 0
+      }
+      this.input.once(
+        'pointerdown',
+        () => {
+          this.input.once(
+            'pointerdown',
+            () => {
+              this.scene.start('ContinueScene', { nextScene: 'BetScene' })
+            },
+            this,
+          )
+        },
+        this,
+      )
+    }
   }
 
   // 勝敗

--- a/src/Phaser/blackjack/config.ts
+++ b/src/Phaser/blackjack/config.ts
@@ -1,6 +1,8 @@
 import Phaser from 'phaser'
 import Blackjack from '@/Phaser/blackjack/BlackjackScene'
 import BetScene from '@/Phaser/common/BetScene'
+import ContinueScene from '@/Phaser/common/ContinueScene'
+import GameOverScene from '@/Phaser/common/GameOverScene'
 
 const gameConfig: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -24,7 +26,7 @@ const gameConfig: Phaser.Types.Core.GameConfig = {
       gravity: { y: 200 },
     },
   },
-  scene: [BetScene, Blackjack],
+  scene: [BetScene, Blackjack, ContinueScene, GameOverScene],
 }
 
 export default gameConfig

--- a/src/Phaser/common/BaseScene.ts
+++ b/src/Phaser/common/BaseScene.ts
@@ -88,4 +88,8 @@ export default class BaseScene extends PreloadScene {
   protected setTimerText(time: string): void {
     if (this.timerText) this.timerText.setText(`${time}`)
   }
+
+  protected gameOver() {
+    this.scene.start('GameOverScene')
+  }
 }

--- a/src/Phaser/common/ContinueScene.ts
+++ b/src/Phaser/common/ContinueScene.ts
@@ -1,0 +1,56 @@
+import BaseScene from '@/Phaser/common/BaseScene'
+import Button from '@/Phaser/common/button'
+import ImageUtility from '@/utility/ImageUtility'
+import { textStyle } from '@/utility/constants'
+
+export default class ContinueScene extends BaseScene {
+  constructor() {
+    super({ key: 'ContinueScene' })
+  }
+
+  private nextScene: string | undefined
+
+  protected YesButton: Button | undefined
+
+  protected NoButton: Button | undefined
+
+  init(data: { nextScene: string }) {
+    this.nextScene = data.nextScene
+  }
+
+  public create() {
+    this.createField()
+
+    this.createButton()
+  }
+
+  private createButton() {
+    const { width, height } = this.scale
+    this.add.text(width * 0.5, height * 0.5, 'Continue?', textStyle).setOrigin(0.5)
+
+    this.YesButton = new Button(this, 0, height / 2, 'chipOrange', 'Yes')
+    this.NoButton = new Button(this, 0, height / 2, 'chipYellow', 'No')
+
+    const buttons: Button[] = new Array<Button>()
+    buttons.push(this.YesButton)
+    buttons.push(this.NoButton)
+
+    ImageUtility.spaceOutImagesEvenlyHorizontally(buttons, this.scene)
+    this.setUpClickHandler(this.YesButton, this.handleYesButton.bind(this))
+    this.setUpClickHandler(this.NoButton, ContinueScene.handleNoButton.bind(this))
+  }
+
+  private setUpClickHandler(button: Button, handlerFunction: Function) {
+    button.on('pointerdown', () => {
+      handlerFunction.call(this)
+    })
+  }
+
+  private handleYesButton(): void {
+    this.scene.start(this.nextScene)
+  }
+
+  private static handleNoButton(): void {
+    window.location.href = '/studio'
+  }
+}

--- a/src/Phaser/common/CpuLevelScene.ts
+++ b/src/Phaser/common/CpuLevelScene.ts
@@ -1,12 +1,14 @@
-import BaseScene from '@/Phaser/common/BaseScene'
+import PreloadScene from '@/Phaser/common/PreloadScene'
 import Button from '@/Phaser/common/button'
 import CpuLevel from '@/model/common/cpuLevel'
 import ImageUtility from '@/utility/ImageUtility'
 
-export default class CpuLevelScene extends BaseScene {
+export default class CpuLevelScene extends PreloadScene {
   constructor() {
     super({ key: 'CpuLevelScene' })
   }
+
+  public gameZone?: Phaser.GameObjects.Zone
 
   protected easyButton: Button | undefined
 
@@ -14,8 +16,31 @@ export default class CpuLevelScene extends BaseScene {
 
   protected hardButton: Button | undefined
 
+  public height: number = 1000
+
+  public width: number = 1000
+
   public create() {
-    this.createField()
+    const { width, height } = this.sys.game.canvas
+    this.height = height
+    this.width = width
+    const table = this.add.image(this.width / 2, this.height / 2, 'betTable')
+    const tableScaleX = this.width / table.width
+    const tableScaleY = this.height / table.height
+    const tableScale = Math.max(tableScaleX, tableScaleY)
+    table.setScale(tableScale)
+
+    this.gameZone = this.add.zone(this.width * 0.5, this.height * 0.5, this.width, this.height)
+
+    const button = this.add.image(100, 100, 'back')
+    const buttonScale = Math.min(this.width / 1920, this.height / 1080) * 1.5
+    button.setScale(buttonScale)
+
+    button.setInteractive()
+
+    button.on('pointerdown', () => {
+      window.location.href = '/studio'
+    })
 
     this.createButton()
   }
@@ -45,16 +70,16 @@ export default class CpuLevelScene extends BaseScene {
 
   private handleEasy(): void {
     this.registry.set('cpuLevel', CpuLevel.EASY)
-    this.scene.start('Speed') // 要変更
+    this.scene.start('Speed')
   }
 
   private handleNormal(): void {
     this.registry.set('cpuLevel', CpuLevel.NORMAL)
-    this.scene.start('Speed') // 要変更
+    this.scene.start('Speed')
   }
 
   private handleHard(): void {
     this.registry.set('cpuLevel', CpuLevel.HARD)
-    this.scene.start('Speed') // 要変更
+    this.scene.start('Speed')
   }
 }

--- a/src/Phaser/common/GameOverScene.ts
+++ b/src/Phaser/common/GameOverScene.ts
@@ -1,0 +1,35 @@
+import BaseScene from '@/Phaser/common/BaseScene'
+import Button from '@/Phaser/common/button'
+import { textStyle } from '@/utility/constants'
+
+export default class GameOverScene extends BaseScene {
+  constructor() {
+    super({ key: 'GameOverScene' })
+  }
+
+  protected RestartButton: Button | undefined
+
+  public create() {
+    this.createField()
+
+    this.createButton()
+  }
+
+  private createButton() {
+    const { width, height } = this.scale
+    this.add.text(width * 0.5, height * 0.5, 'Game Over!', textStyle).setOrigin(0.5)
+    this.RestartButton = new Button(this, width / 2, height * 0.75, 'chipOrange', 'Back')
+
+    this.setUpClickHandler(this.RestartButton, GameOverScene.handleRestartButton.bind(this))
+  }
+
+  private setUpClickHandler(button: Button, handlerFunction: Function) {
+    button.on('pointerdown', () => {
+      handlerFunction.call(this)
+    })
+  }
+
+  private static handleRestartButton(): void {
+    window.location.href = '/studio'
+  }
+}

--- a/src/Phaser/common/PreloadScene.ts
+++ b/src/Phaser/common/PreloadScene.ts
@@ -3,46 +3,58 @@ import { CARD_ATLAS_KEY } from '@/Factories/cardFactory'
 import { loadText } from '@/utility/constants'
 
 export default class PreloadScene extends Phaser.Scene {
+  private progressBox: Phaser.GameObjects.Graphics | null = null
+
+  private progressBar: Phaser.GameObjects.Graphics | null = null
+
+  private loadingText: Phaser.GameObjects.Text | null = null
+
+  private percentText: Phaser.GameObjects.Text | null = null
+
   public preload() {
     const { width, height } = this.cameras.main
     // ロードバーの背景
-    const progressBox = this.add.graphics()
-    progressBox.fillStyle(0x222222, 0.8)
-    progressBox.fillRect(width / 2 - 300, height / 2 - 120, 600, 240)
+    this.progressBox = this.add.graphics()
+    this.progressBox.fillStyle(0x222222, 0.8)
+    this.progressBox.fillRect(width / 2 - 300, height / 2 - 120, 600, 240)
 
     // ロードバーを作成
-    const progressBar = this.add.graphics()
+    this.progressBar = this.add.graphics()
 
     // テキスト
-    const loadingText = this.make.text({
+    this.loadingText = this.make.text({
       x: width / 2,
       y: height / 2 - 50,
       text: 'Loading...',
       style: loadText,
     })
-    loadingText.setOrigin(0.5, 0.5)
+    this.loadingText.setOrigin(0.5, 0.5)
 
-    const percentText = this.make.text({
+    this.percentText = this.make.text({
       x: width / 2,
       y: height / 2 + 30,
       text: '0%',
       style: loadText,
     })
-    percentText.setOrigin(0.5, 0.5)
+    this.percentText.setOrigin(0.5, 0.5)
 
     // ロードイベント
     this.load.on('progress', (value: number) => {
-      percentText.setText(`${Math.floor(value * 100)}%`)
-      progressBar.clear()
-      progressBar.fillStyle(0xffffff, 1)
-      progressBar.fillRect(width / 2 - 150, height / 2 - 30, 300 * value, 30)
+      if (this.percentText && this.progressBar) {
+        this.percentText.setText(`${Math.floor(value * 100)}%`)
+        this.progressBar.clear()
+        this.progressBar.fillStyle(0xffffff, 1)
+        this.progressBar.fillRect(width / 2 - 150, height / 2 - 30, 300 * value, 30)
+      }
     })
 
     this.load.on('complete', () => {
-      progressBar.destroy()
-      progressBox.destroy()
-      loadingText.destroy()
-      percentText.destroy()
+      if (this.progressBox && this.progressBar && this.loadingText && this.percentText) {
+        this.progressBar.destroy()
+        this.progressBox.destroy()
+        this.loadingText.destroy()
+        this.percentText.destroy()
+      }
     })
 
     // アセットの読み込み

--- a/src/Phaser/common/button.ts
+++ b/src/Phaser/common/button.ts
@@ -60,7 +60,7 @@ export default class Button extends Phaser.GameObjects.Image {
   }
 
   public setClickHandler(pushHandler: () => void): void {
-    this.on(
+    this.once(
       'pointerdown',
       () => {
         pushHandler()

--- a/src/Phaser/poker/PokerScene.ts
+++ b/src/Phaser/poker/PokerScene.ts
@@ -110,8 +110,13 @@ export default class Poker extends BaseScene {
     this.callButton = new Button(this, this.width * 0.85, this.height * 0.8, 'chipBlue', 'CALL')
 
     this.callButton.setClickHandler(() => {
-      this.playerBet += this.currentBetAmount
-      this.playerMoney -= this.playerBet
+      if (this.playerMoney < this.currentBetAmount) {
+        this.playerBet += this.playerMoney
+        this.playerMoney = 0
+      } else {
+        this.playerBet += this.currentBetAmount
+        this.playerMoney -= this.playerBet
+      }
       this.player.gameStatus = PlayerAction.CALL
 
       // TODO: チップアニメーション追加
@@ -138,6 +143,9 @@ export default class Poker extends BaseScene {
     }
     this.playerMoney += winAmount
     this.updateMText(this.playerMoney)
+    if (this.playerMoney <= 0) {
+      this.gameOver()
+    }
 
     return {
       gameResult: result,
@@ -244,6 +252,7 @@ export default class Poker extends BaseScene {
       .setDepth(10)
 
     // 初期化
+    this.scene.start('ContinueScene', { nextScene: 'Poker' })
     this.resetRound()
 
     this.time.delayedCall(3000, () => {
@@ -293,8 +302,13 @@ export default class Poker extends BaseScene {
 
     this.raiseButton.setClickHandler(() => {
       this.addRaiseAmount()
-      this.playerBet += this.currentBetAmount
-      this.playerMoney -= this.playerBet
+      if (this.playerMoney < this.currentBetAmount) {
+        this.playerBet += this.playerMoney
+        this.playerMoney = 0
+      } else {
+        this.playerBet += this.currentBetAmount
+        this.playerMoney -= this.playerBet
+      }
       this.player.addBet(this.currentBetAmount)
       this.animateChipToTableCenter(0)
 
@@ -844,6 +858,7 @@ export default class Poker extends BaseScene {
       .text(this.width / 2, this.height / 2, result, textStyle)
       .setOrigin(0.5)
       .setDepth(10)
+    resultText.setColor('#ffde3d')
 
     this.time.delayedCall(4000, () => {
       handRanks.forEach((handRank) => {
@@ -851,6 +866,7 @@ export default class Poker extends BaseScene {
       })
       resultText.destroy()
       this.resetRound()
+      this.scene.start('ContinueScene', { nextScene: 'Poker' })
       this.dealInitialCards()
       this.PlayAnte()
     })

--- a/src/Phaser/poker/config.ts
+++ b/src/Phaser/poker/config.ts
@@ -1,4 +1,6 @@
 import Phaser from 'phaser'
+import ContinueScene from '@/Phaser/common/ContinueScene'
+import GameOverScene from '@/Phaser/common/GameOverScene'
 import Poker from '@/Phaser/poker/PokerScene'
 
 const gameConfig: Phaser.Types.Core.GameConfig = {
@@ -23,7 +25,7 @@ const gameConfig: Phaser.Types.Core.GameConfig = {
       gravity: { y: 200 },
     },
   },
-  scene: [Poker],
+  scene: [Poker, ContinueScene, GameOverScene],
 }
 
 export default gameConfig

--- a/src/Phaser/speed/SpeedScene.ts
+++ b/src/Phaser/speed/SpeedScene.ts
@@ -545,7 +545,7 @@ export default class Speed extends BaseScene {
         this.input.once(
           'pointerdown',
           () => {
-            window.location.href = '/studio'
+            this.scene.start('ContinueScene', { nextScene: 'CpuLevelScene' })
           },
           this,
         )

--- a/src/Phaser/speed/config.ts
+++ b/src/Phaser/speed/config.ts
@@ -1,4 +1,5 @@
 import Phaser from 'phaser'
+import ContinueScene from '@/Phaser/common/ContinueScene'
 import CpuLevelScene from '@/Phaser/common/CpuLevelScene'
 import Speed from '@/Phaser/speed/SpeedScene'
 
@@ -24,7 +25,7 @@ const gameConfig: Phaser.Types.Core.GameConfig = {
       gravity: { y: 200 },
     },
   },
-  scene: [CpuLevelScene, Speed],
+  scene: [CpuLevelScene, Speed, ContinueScene],
 }
 
 export default gameConfig

--- a/src/Phaser/war/WarScene.ts
+++ b/src/Phaser/war/WarScene.ts
@@ -150,8 +150,11 @@ export default class WarScene extends BaseScene {
     Phaser.Display.Align.In.Center(resultText, this.gameZone as Zone)
     setTimeout(() => {
       resultText.destroy()
-      if ((this.deck as Deck).getDeckSize() <= 0) this.handleEndOfGame()
-      this.haveTurn()
+      if ((this.deck as Deck).getDeckSize() <= 0) {
+        this.handleEndOfGame()
+      } else {
+        this.haveTurn()
+      }
     }, 1000)
   }
 
@@ -172,7 +175,7 @@ export default class WarScene extends BaseScene {
     setTimeout(() => {
       resultText.destroy()
       graphics.destroy()
-      window.location.href = '/studio'
+      this.scene.start('ContinueScene', { nextScene: 'WarScene' })
     }, 5000)
   }
 

--- a/src/Phaser/war/config.ts
+++ b/src/Phaser/war/config.ts
@@ -1,4 +1,5 @@
 import Phaser from 'phaser'
+import ContinueScene from '@/Phaser/common/ContinueScene'
 import WarScene from '@/Phaser/war/WarScene'
 
 const gameConfig: Phaser.Types.Core.GameConfig = {
@@ -23,7 +24,7 @@ const gameConfig: Phaser.Types.Core.GameConfig = {
       gravity: { y: 200 },
     },
   },
-  scene: [WarScene],
+  scene: [WarScene, ContinueScene],
 }
 
 export default gameConfig


### PR DESCRIPTION
## チケットへのリンク

- #78, #77 

## やったこと

- ContinueシーンとGameOverSceneの作成
- 各ゲームにこれらのシーンを追加し, エラーを修正
- War, Speedはゲーム終了時にContinue画面が登場し, Yesの場合はCpuLevel選択orゲーム画面に遷移, Noの場合はスタジオ
- Blackjackは1回対戦が終わるごとに, continueシーンにとび, Yesの場合はMoneyを維持したまま次のラウンドを開始（BetSceneへ）, Noの場合はスタジオ. Moneyが0になるとGameOverSceneにとび, スタジオへ戻る
- Pokerも一回対戦が終わるごとにContinueシーン. Yesの場合は継続. Noの場合はスタジオ. Moneyが0になるとGameOver.
- PokerにゲームオーバーとRaiseボタンの連打ができないように改良

## やらないこと

- Pokerでラウンド途中にMoneyがマイナスになってもRaiseボタンを押せたので, 最低入札金額を実装したほうが良いかも

## できるようになること（ユーザ目線）

- ゲームのコンティニュー

## できなくなること（ユーザ目線）

- なし

## 動作確認

- 実際に各ゲームをプレイし, ゲーム中のバグやコンソールでエラーを確認して修正した

## その他

- ゲーム中のエラーは自分がプレイした範囲では修正
- GameOverSceneはPokerでMoneyが0になったときに, ゲームがそのまま実行されるため, シーンを切り替えることで対応した.
