### PR TITLE
Fix/#100 blackjack

### DIFF
--- a/src/Phaser/blackjack/BlackjackScene.ts
+++ b/src/Phaser/blackjack/BlackjackScene.ts
@@ -326,6 +326,10 @@ export default class Blackjack extends BaseScene {
     this.updateBetText()
     if ((<BlackjackPlayer>this.playerHand).getHandScore() > 21) {
       this.endHand(GameResult.BUST)
+    } else {
+      this.handleFlipOver()
+      this.fadeOutButton()
+      setTimeout(() => this.drawCardsUntil17(), 1000)
     }
   }
 

--- a/src/Phaser/blackjack/BlackjackScene.ts
+++ b/src/Phaser/blackjack/BlackjackScene.ts
@@ -113,7 +113,7 @@ export default class Blackjack extends BaseScene {
     }
     this.children.bringToTop(card)
     card.playMoveTween(toX, toY)
-    this.time.delayedCall(500, () => {
+    this.time.delayedCall(700, () => {
       if (isFaceDown && isCardUntil17) {
         card.setFaceDown(true)
         card.playFlipOverTween()
@@ -366,7 +366,7 @@ export default class Blackjack extends BaseScene {
         true,
         true,
       )
-      setTimeout(() => this.drawCardsUntil17(), 500)
+      setTimeout(() => this.drawCardsUntil17(), 1000)
       return
     }
     let result: GameResult

--- a/src/Phaser/blackjack/BlackjackScene.ts
+++ b/src/Phaser/blackjack/BlackjackScene.ts
@@ -94,6 +94,7 @@ export default class Blackjack extends BaseScene {
     toY: number,
     isFaceDown: boolean,
     isEnd?: boolean | undefined,
+    isCardUntil17?: boolean | undefined,
   ): void {
     const card: Card | undefined = deck.drawOne()
 
@@ -112,6 +113,12 @@ export default class Blackjack extends BaseScene {
     }
     this.children.bringToTop(card)
     card.playMoveTween(toX, toY)
+    this.time.delayedCall(500, () => {
+      if (isFaceDown && isCardUntil17) {
+        card.setFaceDown(true)
+        card.playFlipOverTween()
+      }
+    })
   }
 
   // トランプを0.5秒おきに描画する
@@ -355,7 +362,8 @@ export default class Blackjack extends BaseScene {
         this.dealerHand as BlackjackPlayer,
         (this.dealerHandZone as Zone).x + CARD_WIDTH * (handleLen * 0.3 - 0.15),
         (this.dealerHandZone as Zone).y,
-        false,
+        true,
+        true,
         true,
       )
       setTimeout(() => this.drawCardsUntil17(), 500)

--- a/src/Phaser/blackjack/BlackjackScene.ts
+++ b/src/Phaser/blackjack/BlackjackScene.ts
@@ -298,6 +298,8 @@ export default class Blackjack extends BaseScene {
   }
 
   private handleHit(): void {
+    this.doubleButton?.destroy()
+    this.surrenderButton?.destroy()
     const handleLen = (this.playerHand as BlackjackPlayer).hand.length
     this.handOutCard(
       this.deck as Deck,

--- a/src/Phaser/common/BetScene.ts
+++ b/src/Phaser/common/BetScene.ts
@@ -15,6 +15,8 @@ export default class BetScene extends PreloadScene {
 
   public bet: number = 0
 
+  public dealButton: Button | undefined
+
   public moneyText: BitmapText | undefined
 
   public betText: BitmapText | undefined
@@ -101,6 +103,10 @@ export default class BetScene extends PreloadScene {
 
   private addChip(value: number) {
     this.bet += value
+    if (this.dealButton && this.bet > 0) {
+      this.dealButton.visible = true
+      this.dealButton.text.visible = true
+    }
     if (this.bet > this.money) this.bet = this.money
     this.updateBetText()
   }
@@ -138,27 +144,35 @@ export default class BetScene extends PreloadScene {
   // clearボタンとdealボタン
   public setUpButtons(): void {
     const clearButton = new Button(this, 0, this.height * 0.75, 'chipBlue', 'clear')
-    const dealButton = new Button(this, 200, this.height * 0.75, 'chipBlue', 'Deal')
+    this.dealButton = new Button(this, 200, this.height * 0.75, 'chipBlue', 'Deal')
+    this.dealButton.visible = false
+    this.dealButton.text.visible = false
     clearButton.on(
       'pointerdown',
       () => {
         this.bet = 0
         this.sound.play('clear', { volume: 0.1 })
         this.updateBetText()
+        if (this.dealButton) {
+          this.dealButton.visible = false
+          this.dealButton.text.visible = false
+        }
       },
       this,
     )
-    dealButton.on(
+    this.dealButton.on(
       'pointerdown',
       () => {
-        this.sound.play('bet')
-        this.scene.start('Blackjack')
+        if (this.bet > 0) {
+          this.sound.play('bet')
+          this.scene.start('Blackjack')
+        }
       },
       this,
     )
     const buttons: Image[] = new Array<Image>()
     buttons.push(clearButton)
-    buttons.push(dealButton)
+    buttons.push(this.dealButton)
     ImageUtility.spaceOutImagesEvenlyHorizontally(buttons, this.scene)
   }
 }


### PR DESCRIPTION
## チケットへのリンク

- #100 
- #101
- #102

## やったこと

- BetSceneでbetが0の場合はDealボタンを非表示にした
- doubleを押した場合は結果表示に移行
- ディーラーが17になるまで引く場合, カードを引いてから裏表を反転するように変更

## やらないこと

- なし

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし

## 動作確認

- 実際にプレイして確認. 
- 改善した点は動作していた

## その他

- ほかにBlackjackで治すべき箇所があれば, コメントお願いします.
